### PR TITLE
 Fix tests failing to pass level when adding logger. Fix object logging. Add tests for bunyan stream configuration and datum decoration.

### DIFF
--- a/debug/Harness.js
+++ b/debug/Harness.js
@@ -5,7 +5,8 @@ const libFableLoggerBunyan = require('../source/Fable-Log-Logger-Bunyan.js');
 // Initialize fable.
 const _Fable = new libFable({
 	Product: 'fable-log-bunyan-harness',
-	Version: '1.0.0'
+	Version: '1.0.0',
+	LogStreams: [], // disable default logger to only use bunyan
 });
 
 // Add the bunyan logger...
@@ -14,7 +15,7 @@ _Fable.Logging.addLogger(new libFableLoggerBunyan(
 	{
 		name: _Fable.settings.Product,
 		version: _Fable.settings.Version
-	}));
+	}), 'trace');
 
 // Try it out!
 _Fable.log.info('Bunyan do your thing, yo...');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
     "name": "fable-log-logger-bunyan",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fable-log-logger-bunyan",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
                 "bunyan": "^1.8.15",
                 "fable-log": "^3.0.10"
             },
             "devDependencies": {
+                "fable": "^3.0.75",
                 "quackage": "^1.0.19"
             }
         },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
     "description": "Bunyan logger for fable-log.",
     "main": "source/Fable-Log-Logger-Bunyan.js",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "start": "node source/Fable-Log-Logger-Bunyan.js",
         "test": "npx mocha -u tdd --exit",
+        "start": "node source/Fable-Log-Logger-Bunyan.js",
         "tests": "npx mocha -u tdd --exit -R spec --grep",
         "coverage": "npx nyc --reporter=lcov --reporter=text-lcov ./node_modules/mocha/bin/_mocha -- -u tdd -R spec",
         "build": "npx quack build",
@@ -17,6 +16,7 @@
     "author": "steven velozo <steven@velozo.com>",
     "license": "MIT",
     "devDependencies": {
+        "fable": "^3.0.75",
         "quackage": "^1.0.19"
     },
     "mocha": {

--- a/source/Fable-Log-Logger-Bunyan.js
+++ b/source/Fable-Log-Logger-Bunyan.js
@@ -12,32 +12,32 @@ class BunyanLogger extends libBaseLogger
 
 	trace(pLogText, pLogObject)
 	{
-		this.bunyanLogger.trace(pLogText, pLogObject);
+		this.bunyanLogger.trace(pLogObject || { }, pLogText);
 	}
 
 	debug(pLogText, pLogObject)
 	{
-		this.bunyanLogger.debug(pLogText, pLogObject);
+		this.bunyanLogger.debug(pLogObject || { }, pLogText);
 	}
 
 	info(pLogText, pLogObject)
 	{
-		this.bunyanLogger.info(pLogText, pLogObject);
+		this.bunyanLogger.info(pLogObject || { }, pLogText);
 	}
 
 	warn(pLogText, pLogObject)
 	{
-		this.bunyanLogger.warn(pLogText, pLogObject);
+		this.bunyanLogger.warn(pLogObject || { }, pLogText);
 	}
 
 	error(pLogText, pLogObject)
 	{
-		this.bunyanLogger.error(pLogText, pLogObject);
+		this.bunyanLogger.error(pLogObject || { }, pLogText);
 	}
 
 	fatal(pLogText, pLogObject)
 	{
-		this.bunyanLogger.fatal(pLogText, pLogObject);
+		this.bunyanLogger.fatal(pLogObject || { }, pLogText);
 	}
 }
 

--- a/test/Fable-Log-Logger-Bunyan-Basic_test.js
+++ b/test/Fable-Log-Logger-Bunyan-Basic_test.js
@@ -5,9 +5,36 @@
 const Chai = require('chai');
 const Expect = Chai.expect;
 
+const { PassThrough } = require('stream');
 
 const libFable = require('fable');
 const libFableLoggerBunyan = require(`../source/Fable-Log-Logger-Bunyan.js`);
+
+/**
+ * Helper to convert a stream of utf8 bytes to a string.
+ */
+async function streamToString(stream)
+{
+	return new Promise((resolve, reject) =>
+	{
+		const chunks = [];
+		stream.on('data', (chunk) => chunks.push(chunk));
+		stream.on('error', reject);
+		stream.on('end', () =>
+		{
+			if (Buffer.isBuffer(chunks[0]))
+			{
+				resolve(Buffer.concat(chunks).toString('utf8'));
+			}
+			else
+			{
+				// assume it's just a broken string, and stitch together
+				// TODO: can we be more explicit here for the various formats?
+				resolve(chunks.join(''));
+			}
+		});
+	});
+}
 
 suite
 (
@@ -28,7 +55,8 @@ suite
 
 								let _Fable = new libFable({
 									Product: 'fable-log-bunyan-harness',
-									Version: '1.0.0'
+									Version: '1.0.0',
+									LogStreams: [], // no default logger
 								});
 
 								// TODO: Switch these to fable services
@@ -38,13 +66,135 @@ suite
 										name: 'fable-log-bunyan-harness-instance'
 									});
 
-								_Fable.Logging.addLogger(_FableLoggerBunyan);
+								_Fable.Logging.addLogger(_FableLoggerBunyan, 'trace');
 
 								_Fable.log.info('Bunyan do your thing, yo...');
 								_Fable.log.info('Some objects:', { foo: 'bar', baz: 'quux'});
 								_Fable.log.fatal('This was a critical wound.');
 								Expect(_FableLoggerBunyan).to.be.an('object');
 								return fDone();
+							}
+						);
+					test(
+							'Bunyan stream config',
+							async () =>
+							{
+
+								let _Fable = new libFable({
+									Product: 'fable-log-bunyan-harness',
+									Version: '1.0.0',
+									LogStreams: [], // no default logger
+								});
+
+								const passThrough = new PassThrough();
+								// TODO: Switch these to fable services
+								let _FableLoggerBunyan = new libFableLoggerBunyan(
+									// This is passed directly to Bunyan as well.
+									{
+										name: 'fable-log-bunyan-harness-instance',
+										streams:
+										[
+											{
+												level: 'trace',
+												stream: process.stdout,
+											},
+											{
+												level: 'info',
+												stream: passThrough,
+											},
+										],
+									});
+								Expect(_FableLoggerBunyan).to.be.an('object');
+
+								_Fable.Logging.addLogger(_FableLoggerBunyan, 'trace');
+
+								_Fable.log.info('Bunyan do your thing, yo...');
+								_Fable.log.trace('Bunyan should eat me.', { is: 'ignored' });
+								_Fable.log.info('Some objects:', { foo: 'bar', baz: 'quux'});
+								_Fable.log.fatal('This was a critical wound.');
+								passThrough.end();
+
+								const logs = await streamToString(passThrough);
+
+								const logLines = logs.split('\n').filter((l) => !!l); // filter out blank lines (probably last newline)
+								Expect(logLines.length).to.equal(3);
+
+								Expect(logLines[0]).to.include('"Bunyan do your thing, yo..."');
+								let jsonLine = JSON.parse(logLines[0]); // ensure it's valid JSON
+
+								Expect(logLines[1]).to.include('"Some objects:"');
+								jsonLine = JSON.parse(logLines[1]);
+								Expect(jsonLine.foo).to.equal('bar');
+								Expect(jsonLine.baz).to.equal('quux');
+
+								Expect(logLines[2]).to.include('"This was a critical wound."');
+								jsonLine = JSON.parse(logLines[2]); // ensure it's valid JSON
+							}
+						);
+					test(
+							'Bunyan with datum decorator',
+							async () =>
+							{
+
+								let _Fable = new libFable({
+									Product: 'fable-log-bunyan-harness',
+									Version: '1.0.0',
+									LogStreams: [], // no default logger
+								});
+								_Fable.log.setDatumDecorator((sourceDatum) =>
+								{
+									const datum = { };
+									datum.Source = _Fable.settings.Product;
+									datum.Meta = sourceDatum;
+									return datum;
+								});
+
+								const passThrough = new PassThrough();
+								// TODO: Switch these to fable services
+								let _FableLoggerBunyan = new libFableLoggerBunyan(
+									// This is passed directly to Bunyan as well.
+									{
+										name: 'fable-log-bunyan-harness-instance',
+										streams:
+										[
+											{
+												level: 'trace',
+												stream: process.stdout,
+											},
+											{
+												level: 'info',
+												stream: passThrough,
+											},
+										],
+									});
+								Expect(_FableLoggerBunyan).to.be.an('object');
+
+								_Fable.Logging.addLogger(_FableLoggerBunyan, 'trace');
+
+								_Fable.log.info('Bunyan do your thing, yo...');
+								_Fable.log.trace('Bunyan should eat me.', { is: 'ignored' });
+								_Fable.log.info('Some objects:', { foo: 'bar', baz: 'quux'});
+								_Fable.log.fatal('This was a critical wound.');
+								passThrough.end();
+
+								const logs = await streamToString(passThrough);
+
+								const logLines = logs.split('\n').filter((l) => !!l); // filter out blank lines (probably last newline)
+								Expect(logLines.length).to.equal(3);
+
+								let jsonLine = JSON.parse(logLines[0]);
+								Expect(jsonLine.msg).to.equal('Bunyan do your thing, yo...');
+								Expect(jsonLine.Source).to.equal('fable-log-bunyan-harness');
+
+								jsonLine = JSON.parse(logLines[1]);
+								Expect(jsonLine.msg).to.equal('Some objects:');
+								Expect(jsonLine.Source).to.equal('fable-log-bunyan-harness');
+								Expect(jsonLine.Meta.foo).to.equal('bar');
+								Expect(jsonLine.Meta.baz).to.equal('quux');
+
+								jsonLine = JSON.parse(logLines[2]);
+								Expect(jsonLine.msg).to.equal('This was a critical wound.');
+								Expect(jsonLine.Source).to.equal('fable-log-bunyan-harness');
 							}
 						);
 				}


### PR DESCRIPTION
I was trying to get this logger working using the tests as a guide and ran into several issues.

Findings and changes:
* Tests and harness were not passing the log level when adding the logger to fable, so the logger was never used.
  * Disabled the default logger via fable config to make this more obvious.
* Logging with no object was logging `undefined` in the log line.
  * Convert falsy object to `{ }` when logging.
  * Change parameter order.

Additionally, I added tests for multiple bunyan streams and datum decoration (demonstrating how to achieve backward-ish compatibility).